### PR TITLE
docs: fix CHANGELOG spelling and CONTRIBUTING PR target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - upmerge main to develop (#51)
 - Upmerge (#49)
 - corrected
-- reeomove broken files
+- remove broken files
 - load test
-- no promt
+- no prompt
 - format
 - remove unused imports and variables in example unit test
 - fix example tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Steps:
 - Install and build: `npm install` then `npm run build`
 - Run tests (if any): `npm test`
 - Ensure TypeScript compiles: `npm run build`
-- Commit with clear messages and open a Pull Request against `main`.
+- Commit with clear messages and open a Pull Request against `develop`.
 
 Code style:
 


### PR DESCRIPTION
## Summary
- Fixed CHANGELOG.md spelling: "reeomove" → "remove", "no promt" → "no prompt"
- Fixed CONTRIBUTING.md PR target branch: `main` → `develop`

Resolves part of winccoa-tools-pack/.github#73
